### PR TITLE
New super linter

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -36,4 +36,6 @@ jobs:
           VALIDATE_KUBERNETES_KUBECONFORM: false
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_SHELL_SHFMT: false
+          VALIDATE_TEKTON: false
           VALIDATE_YAML: false
+          VALIDATE_YAML_PRETTIER: false

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -21,18 +21,19 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter/slim@v5
+        uses: super-linter/super-linter/slim@v7
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # These are the validation we disable atm
-          VALIDATE_BASH: false
-          VALIDATE_JSCPD: false
-          VALIDATE_KUBERNETES_KUBECONFORM: false
-          VALIDATE_YAML: false
           VALIDATE_ANSIBLE: false
-          VALIDATE_DOCKERFILE_HADOLINT: false
-          # VALIDATE_MARKDOWN: false
-          # VALIDATE_NATURAL_LANGUAGE: false
-          VALIDATE_TEKTON: false
+          VALIDATE_BASH: false
+          VALIDATE_CHECKOV: false
+          VALIDATE_JSCPD: false
+          VALIDATE_JSON_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_KUBERNETES_KUBECONFORM: false
+          VALIDATE_PYTHON_PYLINT: false
+          VALIDATE_SHELL_SHFMT: false
+          VALIDATE_YAML: false


### PR DESCRIPTION
- **Allow originRepo to be set via make install and main.git parameters**
- **resolves #21 rag-llm-gitops**
- **Fix vars that were erroneously dropped**
- **Allow more flexibility with multiSourceConfig schema**
- **Inject VALUES_SECRET env var**
- **Add helmRepoUrl variable**
- **Update letsencrypt to v0.1.1**
- **Allow overriding gitops source on spokes**
- **Update acm chart to v0.1.1**
- **Update clustergroup chart to 0.8.11**
- **Extend the schema for disconnected**
- **Update clustergroup chart to 0.8.12**
- **Update super-linter to v7**
- **Fix action path**
- **Fix action path v2**
- **Upgrade ESO to v0.10.0**
- **Upgrade vault to 1.17.3**
- **Update hashicorp-vault to 0.1.2**
- **Update golang-external-secrets to 0.1.2**
- **Update tests after common rebase**
- **Update super-linter to v7**
