### PR TITLE
Upgrade super-linter to v8.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
 

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -2,5 +2,8 @@
     "default": true,
     "MD003": false,
     "MD013": false,
-    "MD033": false
+    "MD033": false,
+    "MD059": false,
+    "MD060": false,
+    "MD034": false
 }

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -2,16 +2,20 @@ name: Ansible Lint # feel free to pick your own name
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       # Important: This sets up your GITHUB_WORKSPACE environment variable
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Lint Ansible Playbook
-        uses: ansible/ansible-lint-action@v6
+        uses: ansible/ansible-lint@8ba9595a4acd1b906eb75568b34f6ef592cd1528 # v26
         # Let's point it to the path
         with:
-          path: "ansible/"
+          working_directory: "ansible/"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,6 +14,8 @@ on: [push, pull_request]
 ###############
 # Set the Job #
 ###############
+permissions: read-all
+
 jobs:
   build:
     # Name the Job
@@ -29,12 +31,13 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
       - name: Setup helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: 'v3.13.2'
         id: install

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -3,6 +3,8 @@ name: Super linter
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     # Name the Job
@@ -12,8 +14,9 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
@@ -21,10 +24,11 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7
+        uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
+          FILTER_REGEX_EXCLUDE: .+/\.github/.*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # These are the validation we disable atm
           VALIDATE_ANSIBLE: false
@@ -39,3 +43,11 @@ jobs:
           VALIDATE_TEKTON: false
           VALIDATE_YAML: false
           VALIDATE_YAML_PRETTIER: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_PYINK: false
+          VALIDATE_PYTHON_RUFF_FORMAT: false
+          VALIDATE_TRIVY: false


### PR DESCRIPTION
- Pin super-linter to v8.5.0 (SHA 61abc07d)
- Pin all GitHub Actions to SHA references
- Add persist-credentials: false to checkout steps
- Add permissions: read-all to workflow files
- Add dependabot cooldown and grouping configuration
- Disable new v8 linters not applicable to this repo
- Add FILTER_REGEX_EXCLUDE for nested .github directories
- Add zizmor ignore comments for reusable workflow refs
- Update markdownlint config for new rules
- Migrate ansible-lint-action to ansible/ansible-lint

